### PR TITLE
Add separate STL/STEP download buttons and GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react";
 import useAppState from "./useAppState";
 
 import { IconButton, IconGroup } from "./components/buttons.jsx";
-import download from "./download";
+import download, { downloadSTL, downloadSTEP } from "./download";
 
 import UndoIcon from "./icons/Undo";
 import RedoIcon from "./icons/Redo";
@@ -49,6 +49,48 @@ const DownloadButton = observer(() => {
   );
 });
 
+const DownloadSTLButton = observer(() => {
+  const state = useAppState();
+  const [loading, setLoading] = useState(false);
+
+  const dl = async () => {
+    setLoading(true);
+    try {
+      await downloadSTL(state.currentValues);
+    } catch (e) {
+      console.error(e);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <IconButton disabled={!state.shapeLoaded || state.processing} onClick={dl}>
+      {loading ? <LoadingIcon size="1.5em" /> : "STL"}
+    </IconButton>
+  );
+});
+
+const DownloadSTEPButton = observer(() => {
+  const state = useAppState();
+  const [loading, setLoading] = useState(false);
+
+  const dl = async () => {
+    setLoading(true);
+    try {
+      await downloadSTEP(state.currentValues);
+    } catch (e) {
+      console.error(e);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <IconButton disabled={!state.shapeLoaded || state.processing} onClick={dl}>
+      {loading ? <LoadingIcon size="1.5em" /> : "STEP"}
+    </IconButton>
+  );
+});
+
 export default observer(() => {
   const state = useAppState();
   const [selected, setSelected] = useState("rowsAndCols");
@@ -70,7 +112,10 @@ export default observer(() => {
             <RedoIcon />
           </IconButton>
         </IconGroup>
-        <DownloadButton />
+        <IconGroup>
+          <DownloadSTLButton />
+          <DownloadSTEPButton />
+        </IconGroup>
       </EditButtons>
       <select
         id="type-select"

--- a/src/download.js
+++ b/src/download.js
@@ -3,6 +3,16 @@ import JSZip from "jszip";
 import FileSaver from "file-saver";
 import api from "./api";
 
+export const downloadSTL = async (model) => {
+  const stlBlob = await api.createSTL(model);
+  FileSaver.saveAs(stlBlob, "hsw.stl");
+};
+
+export const downloadSTEP = async (model) => {
+  const stepBlob = await api.createSTEP(model);
+  FileSaver.saveAs(stepBlob, "hsw.step");
+};
+
 export default async (model) => {
   const waitToBeDone = [];
   const zip = new JSZip();

--- a/src/menus/EditPlateShape.jsx
+++ b/src/menus/EditPlateShape.jsx
@@ -16,6 +16,26 @@ export default observer(
       state.config.profileConfig.disableBottom
     );
 
+    const updateLeft = (value) => {
+      setLeft(value);
+      state.updateProfile({ disableLeft: value });
+    };
+
+    const updateRight = (value) => {
+      setRight(value);
+      state.updateProfile({ disableRight: value });
+    };
+
+    const updateTop = (value) => {
+      setTop(value);
+      state.updateProfile({ disableTop: value });
+    };
+
+    const updateBottom = (value) => {
+      setBottom(value);
+      state.updateProfile({ disableBottom: value });
+    };
+
     useImperativeHandle(ref, () => {
       return {
         saveChanges: () => {
@@ -41,7 +61,7 @@ export default observer(
             id="left"
             type="checkbox"
             checked={left}
-            onChange={(e) => setLeft(e.target.checked)}
+            onChange={(e) => updateLeft(e.target.checked)}
           />
           <label htmlFor="left">Left</label>
         </BaseInline>
@@ -50,7 +70,7 @@ export default observer(
             id="top"
             type="checkbox"
             checked={top}
-            onChange={(e) => setTop(e.target.checked)}
+            onChange={(e) => updateTop(e.target.checked)}
           />
           <label htmlFor="top">Top</label>
         </BaseInline>
@@ -59,7 +79,7 @@ export default observer(
             id="right"
             type="checkbox"
             checked={right}
-            onChange={(e) => setRight(e.target.checked)}
+            onChange={(e) => updateRight(e.target.checked)}
           />
           <label htmlFor="right">Right</label>
         </BaseInline>
@@ -68,7 +88,7 @@ export default observer(
             id="bottom"
             type="checkbox"
             checked={bottom}
-            onChange={(e) => setBottom(e.target.checked)}
+            onChange={(e) => updateBottom(e.target.checked)}
           />
           <label htmlFor="bottom">Bottom</label>
         </BaseInline>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import reactPlugin from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [reactPlugin()],
+  base: "/hsw-generator/",
   build: {
     outDir: "build",
   },


### PR DESCRIPTION
- Split download functionality into separate STL and STEP buttons
- Add GitHub Actions workflow for automated GitHub Pages deployment
- Configure vite.config.js with base path for GitHub Pages
- Update flat borders UI to apply changes immediately without clicking Apply button
- Improve user experience with instant preview updates